### PR TITLE
fix: different sizes of cards

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -47,13 +47,13 @@ export default function Page() {
           </p>
         </div>
       </div>
-      <div className="flex flex-col 2xl:flex-row justify-between gap-24 xl:gap-8">
+      <div className="flex flex-col 2xl:flex-row justify-between gap-4 2xl:gap-8">
         <div className="flex flex-col w-full 2xl:w-1/2">
           <h2 className="my-4 text-3xl font-medium">Schedule</h2>
           {favorites.filter((v) => v.predefined === true).length === 0 ? (
             <p className="mb-4 text-lg text-text-secondary/75">Nothing here.</p>
           ) : (
-            <div className="mb-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-2 4xl:grid-cols-3 gap-4 justify-stretch">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-2 4xl:grid-cols-3 gap-4 justify-stretch">
               {favorites
                 .filter((v) => v.predefined === true)
                 .map((v) => (

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -47,26 +47,33 @@ export default function Page() {
           </p>
         </div>
       </div>
-      <div className="flex flex-col flex-wrap xl:flex-row xl:justify-between">
-        <div className="min-w-[20%] lg:min-w-[30%] xl:max-w-[45%]">
+      <div className="flex flex-col 2xl:flex-row justify-between gap-24 xl:gap-8">
+        <div className="flex flex-col w-full 2xl:w-1/2">
           <h2 className="my-4 text-3xl font-medium">Schedule</h2>
           {favorites.filter((v) => v.predefined === true).length === 0 ? (
             <p className="mb-4 text-lg text-text-secondary/75">Nothing here.</p>
           ) : (
-            <div className="mb-4 grid w-full grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="mb-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-2 4xl:grid-cols-3 gap-4 justify-stretch">
               {favorites
                 .filter((v) => v.predefined === true)
                 .map((v) => (
+                    <>
                   <GroupCard
                     key={v.event_group.path}
                     group={v.event_group}
                     canHide={true}
                   />
+                  <GroupCard
+                  key={v.event_group.path}
+                group={v.event_group}
+                canHide={true}
+            />
+                    </>
                 ))}
             </div>
           )}
         </div>
-        <div className="min-w-[20%] lg:min-w-[30%] xl:max-w-[50%]">
+        <div className="flex flex-col w-full 2xl:w-1/2">
           <h2 className="my-4 text-3xl font-medium">Favorites</h2>
           {favorites.filter((v) => v.predefined === false).length === 0 ? (
             <p className="mb-4 text-lg text-text-secondary/75">
@@ -77,7 +84,7 @@ export default function Page() {
               </Link>
             </p>
           ) : (
-            <div className="mb-4 grid w-full grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="mb-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-2 4xl:grid-cols-3 gap-4 justify-stretch">
               {favorites
                 .filter((v) => v.predefined === false)
                 .map((v) => (

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -53,7 +53,7 @@ export default function Page() {
           {favorites.filter((v) => v.predefined === true).length === 0 ? (
             <p className="mb-4 text-lg text-text-secondary/75">Nothing here.</p>
           ) : (
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-2 4xl:grid-cols-3 gap-4 justify-stretch">
+            <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-2 4xl:grid-cols-3 gap-4 justify-stretch">
               {favorites
                 .filter((v) => v.predefined === true)
                 .map((v) => (
@@ -84,7 +84,7 @@ export default function Page() {
               </Link>
             </p>
           ) : (
-            <div className="mb-4 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-2 4xl:grid-cols-3 gap-4 justify-stretch">
+            <div className="mb-4 grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-2 4xl:grid-cols-3 gap-4 justify-stretch">
               {favorites
                 .filter((v) => v.predefined === false)
                 .map((v) => (

--- a/components/schedule/group-card/GroupCard.tsx
+++ b/components/schedule/group-card/GroupCard.tsx
@@ -29,7 +29,7 @@ export function GroupCard({ group, canHide = false }: GroupCardProps) {
 
   return (
     <div
-      className="flex min-h-fit min-w-fit max-w-full cursor-pointer flex-row items-center justify-between rounded-2xl bg-primary-main p-4 hover:bg-primary-hover"
+      className="flex min-h-fit min-w-fit max-w-full basis-72 cursor-pointer flex-row items-center justify-between rounded-2xl bg-primary-main p-4 hover:bg-primary-hover"
       onClick={() => router.push(eventGroupPageURL)}
       onMouseEnter={() => router.prefetch(eventGroupPageURL)}
     >

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -60,6 +60,7 @@ module.exports = {
         "lg-h": { raw: "(min-height: 1024px)" },
         "xl-h": { raw: "(min-height: 1280px)" },
         "2xl-h": { raw: "(min-height: 1536px)" },
+        "4xl": { raw: "(min-width: 2048px)"},
       },
       spacing: {
         "18p": "4.5rem",


### PR DESCRIPTION
This PR will fix different sizes of cards.
~~Also, this PR would possibly include #85 (adding a plugin for breakpoints).~~ It will be included in separate PR.

The changes which are introduced by this PR:
- Grid
  - section containers: `flex-direction: row` from the `2xl` breakpoint (>1536px laptop)
  - various `grid-template-columns` for different breakpoints 
    - 1 for phones
    - 2 for `sm` (tablets) and `2xl` (since the `flex-direction: row`, there is less space for 3 columns)
    - 3 for `xl` (grid takes full container width, since `flex-direction: column`) and `4xl` (too much space, excessive stretch)
- Basis size for GroupCard component (so it will be not so small)
- Margins
  - fix of inconsistent margins (2rem now between each section of GroupCards in dashboard)