### PR TITLE
Adjust BottomNavigation when using PWA

### DIFF
--- a/src/components/layout/BottomNavigation.tsx
+++ b/src/components/layout/BottomNavigation.tsx
@@ -1,4 +1,5 @@
 import { Link, LinkOptions } from "@tanstack/react-router";
+import clsx from "clsx";
 import React, { PropsWithChildren, ReactElement } from "react";
 
 export function BottomNavigation() {
@@ -24,7 +25,10 @@ export function BottomNavigation() {
 
   return (
     <nav
-      className={`bg-floating flex ${isPWA ? "px-6 pt-1 pb-6" : "h-12"} w-full shrink-0 overflow-hidden lg:hidden`}
+      className={clsx(
+        "bg-floating flex w-full shrink-0 overflow-hidden lg:hidden",
+        isPWA ? "px-6 pt-1 pb-6" : "h-12",
+      )}
     >
       <BottomNavigationLink
         to="/dashboard"


### PR DESCRIPTION
When I installed InNoHassle as a PWA, I noticed that bottom navigation was barely usable due to phone navigation getting in the way, this PR fixes that without affecting website users

**Before:**
<img width="404" height="178" alt="image" src="https://github.com/user-attachments/assets/efae8152-9447-4ea1-8135-f694b3af79fe" />


**After:**
<img width="754" height="298" alt="CleanShot 2025-11-02 at 2  51 32@2x" src="https://github.com/user-attachments/assets/def588ba-83d9-4bce-8a74-fa78a5544dfc" />



 