### PR TITLE
fix(room-booking): fixed error handling when booking is declined

### DIFF
--- a/src/api/helpers/create-query-client.ts
+++ b/src/api/helpers/create-query-client.ts
@@ -81,12 +81,20 @@ export function formatApiErrorMessage(
     typeof (error as { httpCode: unknown }).httpCode === "number"
   ) {
     const apiError = error as { body?: unknown; httpCode: number };
-    const detail = (
-      apiError.body as { detail?: unknown } | undefined
-    )?.detail?.toString();
+    const detail = (apiError.body as { detail?: unknown } | undefined)?.detail;
     const code = apiError.httpCode.toString();
     if (detail) {
-      return `Error ${code}: ${detail}`;
+      if (typeof detail === "string") {
+        return `Error ${code}: ${detail}`;
+      }
+      if (
+        typeof detail === "object" &&
+        detail !== null &&
+        "message" in detail
+      ) {
+        return `Error ${code}: ${detail.message as string}`;
+      }
+      return `Error ${code}: ${JSON.stringify(detail)}`;
     }
     return `Error ${code}`;
   }


### PR DESCRIPTION
### Description of changes

When room booking is declined by outlook, error was returned as an object, but string expected. Since that, Error 403: [object Object] appeared on frondend. I added additional conditions to always satisfy object type and extract message from "details" object